### PR TITLE
Two minor changes to where files are written

### DIFF
--- a/global_ndr_plus_pipeline.py
+++ b/global_ndr_plus_pipeline.py
@@ -713,17 +713,25 @@ def main():
     ecoshard_path_map = {}
     LOGGER.info('scheduling downloads')
     LOGGER.debug('starting downloads')
+    local_cache_dir = '/home/groups/gdaily/nci-local-ecoshard-cache'
     for ecoshard_id, ecoshard_url in ECOSHARDS.items():
-        # If the ecoshard path is local, just use that.
+        ecoshard_basename = os.path.basename(ecoshard_url)
+        # If the ecoshard path is local and where we expect, just use that.
         if os.path.exists(ecoshard_url):
             LOGGER.info(f'Using local ecoshard {ecoshard_url}')
             ecoshard_path = ecoshard_url
+
+        # In case the ecoshard path is in the ecoshard cache directory, use
+        # that.
+        elif os.path.exists(
+                os.path.join(local_cache_dir, ecoshard_basename)):
+            ecoshard_path = os.path.join(local_cache_dir, ecoshard_basename)
 
         # Otherwise, download the ecoshard.
         else:
             LOGGER.info(f'Downloading ecoshard {ecoshard_url}')
             ecoshard_path = os.path.join(
-                ECOSHARD_DIR, os.path.basename(ecoshard_url))
+                ECOSHARD_DIR, ecoshard_basename)
             download_task = task_graph.add_task(
                 func=ecoshard.download_url,
                 args=(ecoshard_url, ecoshard_path),

--- a/global_ndr_plus_pipeline.py
+++ b/global_ndr_plus_pipeline.py
@@ -28,7 +28,13 @@ import taskgraph
 gdal.SetCacheMax(2**27)
 logging.getLogger('taskgraph').setLevel(logging.INFO)
 
-WORKSPACE_DIR = 'global_ndr_plus_workspace'
+# Using an ENV-defined workspace means we can run multiple individual scenarios
+# in different workspaces separately.
+try:
+    WORKSPACE_DIR = os.environ['WORKSPACE_DIR']
+except KeyError:
+    WORKSPACE_DIR = 'global_ndr_plus_workspace'
+
 ECOSHARD_DIR = os.path.join(WORKSPACE_DIR, 'ecoshards')
 SCRUB_DIR = os.path.join(ECOSHARD_DIR, 'scrubbed_ecoshards')
 WORK_STATUS_DATABASE_PATH = os.path.join(WORKSPACE_DIR, 'work_status.db')

--- a/global_ndr_plus_pipeline.py
+++ b/global_ndr_plus_pipeline.py
@@ -786,20 +786,12 @@ def main():
     for ecoshard_id_to_scrub in SCRUB_IDS:
         ecoshard_path = ecoshard_path_map[ecoshard_id_to_scrub]
 
-        # Check the nodata value.  If no nodata value is set, assume it should
-        # be nan.  This is the case for the March, 2022 fertilizer application
-        # rasters.
-        target_nodata = pygeoprocessing.get_raster_info(
-            ecoshard_path)['nodata'][0]
-        if target_nodata is None:
-            target_nodata = float('nan')
-
         scrub_path = os.path.join(SCRUB_DIR, os.path.basename(ecoshard_path))
         task_graph.add_task(
             func=scrub_raster,
             args=(ecoshard_path, scrub_path),
             kwargs={
-                'target_nodata': target_nodata,
+                'target_nodata': float(numpy.finfo(numpy.float32).min),
             },
             target_path_list=[scrub_path],
             task_name=f'scrub {ecoshard_path}')

--- a/global_ndr_plus_pipeline.py
+++ b/global_ndr_plus_pipeline.py
@@ -35,6 +35,11 @@ try:
 except KeyError:
     WORKSPACE_DIR = 'global_ndr_plus_workspace'
 
+try:
+    LOCAL_ECOSHARD_CACHE_DIR = os.environ['ECOSHARD_CACHE_DIR']
+except KeyError:
+    LOCAL_ECOSHARD_CACHE_DIR = '/home/groups/gdaily/nci-local-ecoshard-cache'
+
 ECOSHARD_DIR = os.path.join(WORKSPACE_DIR, 'ecoshards')
 SCRUB_DIR = os.path.join(ECOSHARD_DIR, 'scrubbed_ecoshards')
 WORK_STATUS_DATABASE_PATH = os.path.join(WORKSPACE_DIR, 'work_status.db')
@@ -713,7 +718,6 @@ def main():
     ecoshard_path_map = {}
     LOGGER.info('scheduling downloads')
     LOGGER.debug('starting downloads')
-    local_cache_dir = '/home/groups/gdaily/nci-local-ecoshard-cache'
     for ecoshard_id, ecoshard_url in ECOSHARDS.items():
         ecoshard_basename = os.path.basename(ecoshard_url)
         # If the ecoshard path is local and where we expect, just use that.
@@ -724,8 +728,9 @@ def main():
         # In case the ecoshard path is in the ecoshard cache directory, use
         # that.
         elif os.path.exists(
-                os.path.join(local_cache_dir, ecoshard_basename)):
-            ecoshard_path = os.path.join(local_cache_dir, ecoshard_basename)
+                os.path.join(LOCAL_ECOSHARD_CACHE_DIR, ecoshard_basename)):
+            ecoshard_path = os.path.join(
+                LOCAL_ECOSHARD_CACHE_DIR, ecoshard_basename)
 
         # Otherwise, download the ecoshard.
         else:

--- a/global_ndr_plus_pipeline.py
+++ b/global_ndr_plus_pipeline.py
@@ -36,6 +36,12 @@ except KeyError:
     WORKSPACE_DIR = 'global_ndr_plus_workspace'
 
 try:
+    if not os.path.exists(WORKSPACE_DIR):
+        os.makedirs(WORKSPACE_DIR)
+except OSError as e:
+    print(f"Could not make workspace dir at import: {e}")
+
+try:
     LOCAL_ECOSHARD_CACHE_DIR = os.environ['ECOSHARD_CACHE_DIR']
 except KeyError:
     LOCAL_ECOSHARD_CACHE_DIR = '/home/groups/gdaily/nci-local-ecoshard-cache'

--- a/global_ndr_plus_pipeline.py
+++ b/global_ndr_plus_pipeline.py
@@ -318,17 +318,24 @@ def scrub_raster(
         scrub_nodata = target_nodata
 
     non_finite_count = 0
+    nan_count = 0
     large_value_count = 0
     close_to_nodata = 0
 
     def _scrub_op(base_array):
         nonlocal non_finite_count
+        nonlocal nan_count
         nonlocal large_value_count
         nonlocal close_to_nodata
+
         result = numpy.copy(base_array)
         non_finite_mask = ~numpy.isfinite(result)
         non_finite_count += numpy.count_nonzero(non_finite_mask)
         result[non_finite_mask] = scrub_nodata
+
+        nan_mask = numpy.isnan(result)
+        nan_count += numpy.count_nonzero(nan_mask)
+        result[nan_mask] = scrub_nodata
 
         large_value_mask = numpy.abs(result) >= max_abs
         large_value_count += numpy.count_nonzero(large_value_mask)
@@ -350,6 +357,7 @@ def scrub_raster(
         LOGGER.warning(
             f'{base_raster_path} scrubbed these values:\n'
             f'\n\tnon_finite_count: {non_finite_count}'
+            f'\n\tnan_count: {nan_count}'
             f'\n\tlarge_value_count: {large_value_count}'
             f'\n\tclose_to_nodata: {close_to_nodata} '
             f'\n\tto the nodata value of: {scrub_nodata}')

--- a/global_ndr_plus_pipeline.py
+++ b/global_ndr_plus_pipeline.py
@@ -783,8 +783,17 @@ def main():
     invalid_value_task_list = []
     LOGGER.debug('scheduling scrub of requested data')
     os.makedirs(SCRUB_DIR, exist_ok=True)
-    for ecoshard_id_to_scrub, target_nodata in SCRUB_IDS.items():
+    for ecoshard_id_to_scrub in SCRUB_IDS:
         ecoshard_path = ecoshard_path_map[ecoshard_id_to_scrub]
+
+        # Check the nodata value.  If no nodata value is set, assume it should
+        # be nan.  This is the case for the March, 2022 fertilizer application
+        # rasters.
+        target_nodata = pygeoprocessing.get_raster_info(
+            ecoshard_path)['nodata'][0]
+        if target_nodata is None:
+            target_nodata = float('nan')
+
         scrub_path = os.path.join(SCRUB_DIR, os.path.basename(ecoshard_path))
         task_graph.add_task(
             func=scrub_raster,

--- a/global_ndr_plus_pipeline.py
+++ b/global_ndr_plus_pipeline.py
@@ -76,18 +76,18 @@ SCENARIOS = {}
 SCRUB_IDS = set()
 
 
-def _setup_logger(name, log_file, level):
+def _setup_logger(name, log_filename, level):
     """Create arbitrary logger to file.
 
     Args:
         name (str): arbitrary name of logger
-        log_file (str): path to file to log to
+        log_filename (str): filename in workspace to log to
         level (logging.LEVEL): the log level to report.
 
     Return:
         logger object
     """
-    handler = logging.FileHandler(log_file)
+    handler = logging.FileHandler(os.path.join(WORKSPACE_DIR, log_filename))
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
     handler.setFormatter(formatter)
     logger = logging.getLogger(name)

--- a/global_ndr_plus_pipeline.py
+++ b/global_ndr_plus_pipeline.py
@@ -783,12 +783,15 @@ def main():
     invalid_value_task_list = []
     LOGGER.debug('scheduling scrub of requested data')
     os.makedirs(SCRUB_DIR, exist_ok=True)
-    for ecoshard_id_to_scrub in SCRUB_IDS:
+    for ecoshard_id_to_scrub, target_nodata in SCRUB_IDS.items():
         ecoshard_path = ecoshard_path_map[ecoshard_id_to_scrub]
         scrub_path = os.path.join(SCRUB_DIR, os.path.basename(ecoshard_path))
         task_graph.add_task(
             func=scrub_raster,
             args=(ecoshard_path, scrub_path),
+            kwargs={
+                'target_nodata': target_nodata,
+            },
             target_path_list=[scrub_path],
             task_name=f'scrub {ecoshard_path}')
         ecoshard_path_map[ecoshard_id_to_scrub] = scrub_path

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -85,6 +85,8 @@ SCRUB_IDS = {
     'intensificationnapp_rainfed_bmps',
     'intensificationnapp_irrigated',
     'intensificationnapp_rainfed',
+    'baseline_fertilizer',
+    'baseline_lulc',
 }
 
 # DEFINE SCENARIOS HERE SPECIFYING 'lulc_id', 'precip_id', 'fertilizer_id', and 'biophysical_table_id'

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -71,7 +71,7 @@ ECOSHARDS = {
 # JD sanity check to make sure these files exist.
 for key, value in ECOSHARDS.items():
     if value.startswith(SHERLOCK_SCRATCH):
-        assert os.path.exists(value)
+        assert os.path.exists(value), f'File not found: {value}'
 
 # put IDs here that need to be scrubbed, you may know these a priori or you
 # may run the pipeline and see an error and realize you need to add them

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -1,8 +1,6 @@
 """CBD Global NDR scenario."""
 import os
 
-import numpy
-
 # All links in this dict is an ecoshard that will be downloaded to
 # ECOSHARD_DIR
 ECOSHARD_PREFIX = 'https://storage.googleapis.com/'
@@ -70,7 +68,7 @@ for key, value in ECOSHARDS.items():
 
 # put IDs here that need to be scrubbed, you may know these a priori or you
 # may run the pipeline and see an error and realize you need to add them
-float_nan = float(numpy.nan)
+float_nan = float('nan')
 SCRUB_IDS = {
     'intensificationnapp_irrigated_bmps': float_nan,
     'intensificationnapp_rainfed_bmps': float_nan,

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -66,6 +66,12 @@ ECOSHARDS = {
     # https://drive.google.com/drive/u/1/folders/13g52ihP7G2WrYuzl6-gO9yuCwhD3AEw-
     # The grazing_expansion_lulc and restoration_lulc were already ecosharded.
     'forestry_expansion_lulc': f'{SHERLOCK_SCRATCH}/nci-ecoshards/forestry_expansion_md5_215cd2a3db0c8a1a5451f395e87568ec.tif',
+
+    # Section 5 - these are additional files that Rafa and Becky said should be
+    # used for the new "baseline" scenario.
+    'baseline_lulc': f'{SHERLOCK_SCRATCH}/nci-ecoshards/modifiedESA_2022_06_03_md5_7dc8402ad44251e8021f4a72559e5f32.tif',
+    'baseline_fertilizer': f'{SHERLOCK_SCRATCH}/nci-ecoshards/current_n_app_md5_a7e226b3418504591095a704c2409f16.tif',
+    '
 }
 
 # JD sanity check to make sure these files exist.
@@ -163,4 +169,10 @@ SCENARIOS = {
         'fertilizer_id': 'extensificationnapp_rainfedfootprint_gapfilled',
         'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',
     },
+    'baseline': {
+        'lulc_id': 'baseline_lulc'
+        'precip_id': 'worldclim_2015',
+        'fertilizer_id': 'baseline_fertilizer',
+        'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',
+    }
 }

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -71,7 +71,6 @@ ECOSHARDS = {
     # used for the new "baseline" scenario.
     'baseline_lulc': f'{SHERLOCK_SCRATCH}/nci-ecoshards/modifiedESA_2022_06_03_md5_7dc8402ad44251e8021f4a72559e5f32.tif',
     'baseline_fertilizer': f'{SHERLOCK_SCRATCH}/nci-ecoshards/current_n_app_md5_a7e226b3418504591095a704c2409f16.tif',
-    '
 }
 
 # JD sanity check to make sure these files exist.
@@ -170,7 +169,7 @@ SCENARIOS = {
         'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',
     },
     'baseline': {
-        'lulc_id': 'baseline_lulc'
+        'lulc_id': 'baseline_lulc',
         'precip_id': 'worldclim_2015',
         'fertilizer_id': 'baseline_fertilizer',
         'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -1,6 +1,8 @@
 """CBD Global NDR scenario."""
 import os
 
+import numpy
+
 # All links in this dict is an ecoshard that will be downloaded to
 # ECOSHARD_DIR
 ECOSHARD_PREFIX = 'https://storage.googleapis.com/'
@@ -68,13 +70,14 @@ for key, value in ECOSHARDS.items():
 
 # put IDs here that need to be scrubbed, you may know these a priori or you
 # may run the pipeline and see an error and realize you need to add them
-SCRUB_IDS = set([
-    'intensificationnapp_irrigated_bmps',
-    'intensificationnapp_rainfed_bmps',
-    'extensificationnapp_rainfedfootprint_gapfilled',
-    'intensificationnapp_irrigated',
-    'intensificationnapp_rainfed',
-])
+float_nan = float(numpy.nan)
+SCRUB_IDS = {
+    'intensificationnapp_irrigated_bmps': float_nan,
+    'intensificationnapp_rainfed_bmps': float_nan,
+    'extensificationnapp_rainfedfootprint_gapfilled': float_nan,
+    'intensificationnapp_irrigated': float_nan,
+    'intensificationnapp_rainfed': float_nan,
+}
 
 # DEFINE SCENARIOS HERE SPECIFYING 'lulc_id', 'precip_id', 'fertilizer_id', and 'biophysical_table_id'
 # name the key of the scenario something unique

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -86,7 +86,6 @@ SCRUB_IDS = {
     'intensificationnapp_irrigated',
     'intensificationnapp_rainfed',
     'baseline_fertilizer',
-    'baseline_lulc',
 }
 
 # DEFINE SCENARIOS HERE SPECIFYING 'lulc_id', 'precip_id', 'fertilizer_id', and 'biophysical_table_id'

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -68,7 +68,13 @@ for key, value in ECOSHARDS.items():
 
 # put IDs here that need to be scrubbed, you may know these a priori or you
 # may run the pipeline and see an error and realize you need to add them
-SCRUB_IDS = set()
+SCRUB_IDS = set([
+    'intensificationnapp_irrigated_bmps',
+    'intensificationnapp_rainfed_bmps',
+    'extensificationnapp_rainfedfootprint_gapfilled',
+    'intensificationnapp_irrigated',
+    'intensificationnapp_rainfed',
+])
 
 # DEFINE SCENARIOS HERE SPECIFYING 'lulc_id', 'precip_id', 'fertilizer_id', and 'biophysical_table_id'
 # name the key of the scenario something unique

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -1,10 +1,14 @@
 """CBD Global NDR scenario."""
+import os
+
 # All links in this dict is an ecoshard that will be downloaded to
 # ECOSHARD_DIR
 ECOSHARD_PREFIX = 'https://storage.googleapis.com/'
 
 BIOPHYSICAL_TABLE_IDS = {
     'nci-ndr-biophysical_table_forestry_grazing': 'ID', }
+
+SHERLOCK_SCRATCH = os.environ['SCRATCH']
 
 # ADD NEW DATA HERE
 ECOSHARDS = {
@@ -25,19 +29,42 @@ ECOSHARDS = {
     'grazing_expansion_lulc': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/scenarios0221_grazing_expansion_md5_140803bc8aef02a1742aa1d1757e9e76.tif',
     'restoration': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/scenarios0221_restoration_md5_16450b43f0a232b32a847c9738affda3.tif',
     'sustainable_current': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/scenarios0321_sustainable_current_md5_82afe022ffa8485a9b10154ee844b54f.tif',
+
     # Fertilizer
+    ## Section 1 - these were already commented out by the time I (JD) got here
+    ## with the first runs on Sherlock in October, 2021.
     #'intensificationnapp_allcrops_irrigated_max_model_and_observednapprevb_bmps': f'{ECOSHARD_PREFIX}nci-ecoshards/scenarios050420/IntensificationNapp_allcrops_irrigated_max_Model_and_observedNappRevB_BMPs_md5_ddc000f7ce7c0773039977319bcfcf5d.tif',
     #'intensificationnapp_allcrops_rainfed_max_model_and_observednapprevb_bmps': f'{ECOSHARD_PREFIX}nci-ecoshards/scenarios050420/IntensificationNapp_allcrops_rainfed_max_Model_and_observedNappRevB_BMPs_md5_fa2684c632ec2d0e0afb455b41b5d2a6.tif',
     #'extensificationnapp_allcrops_rainfedfootprint_gapfilled_observednapprevb': f'{ECOSHARD_PREFIX}nci-ecoshards/scenarios050420/ExtensificationNapp_allcrops_rainfedfootprint_gapfilled_observedNappRevB_md5_1185e457751b672c67cc8c6bf7016d03.tif',
     #'intensificationnapp_allcrops_irrigated_max_model_and_observednapprevb': f'{ECOSHARD_PREFIX}nci-ecoshards/scenarios050420/IntensificationNapp_allcrops_irrigated_max_Model_and_observedNappRevB_md5_9331ed220772b21f4a2c81dd7a2d7e10.tif',
     #'intensificationnapp_allcrops_rainfed_max_model_and_observednapprevb': f'{ECOSHARD_PREFIX}nci-ecoshards/scenarios050420/IntensificationNapp_allcrops_rainfed_max_Model_and_observedNappRevB_md5_1df3d8463641ffc6b9321e73973f3444.tif',
-    'intensificationnapp_irrigated_bmps': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratesirrigatedRevQ_BMPs_add_background_md5_a1bd38eaffd702079ab36c0bc46d770d.tif',
-    'intensificationnapp_rainfed_bmps': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratesrainfedRevQ_BMPs_add_background_md5_b2232462adcae42eb8c1bf3403a0cf6b.tif',
-    'extensificationnapp_rainfedfootprint_gapfilled': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratescurrentRevQ_add_background_md5_bd57fc740fe61b99133a4e22d3e89ece.tif',
-    'intensificationnapp_irrigated': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratesirrigatedRevQ_add_background_md5_b763d688a87360d37868d6a0fbd6b68a.tif',
-    'intensificationnapp_rainfed': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratesrainfedRevQ_add_background_md5_9f6a8dd89d25e4d7c413d268731a14f8.tif',
+
+    ## Section 2 - these were the fertilizer application rasters used for the
+    ## October, 2021 runs of NCI on Sherlock that I (JD) triggered.
+    #'intensificationnapp_irrigated_bmps': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratesirrigatedRevQ_BMPs_add_background_md5_a1bd38eaffd702079ab36c0bc46d770d.tif',
+    #'intensificationnapp_rainfed_bmps': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratesrainfedRevQ_BMPs_add_background_md5_b2232462adcae42eb8c1bf3403a0cf6b.tif',
+    #'extensificationnapp_rainfedfootprint_gapfilled': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratescurrentRevQ_add_background_md5_bd57fc740fe61b99133a4e22d3e89ece.tif',
+    #'intensificationnapp_irrigated': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratesirrigatedRevQ_add_background_md5_b763d688a87360d37868d6a0fbd6b68a.tif',
+    #'intensificationnapp_rainfed': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/finaltotalNfertratesrainfedRevQ_add_background_md5_9f6a8dd89d25e4d7c413d268731a14f8.tif',
+
+    ## Section 3 - these are the fertilizer application rasters that Peter made
+    ## in early March, 2022 in response to Becky noticing that there was
+    ## something wrong with the previous fertilizer rasters.
+    ##
+    ## These are located on the Sherlock $SCRATCH partition because Rich took
+    ## over control of the ecoshards project on GCP and I can't just upload
+    ## these ecoshards there at the moment.
+    'intensificationnapp_irrigated_bmps': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_irrigated_n_app_bmps_md5_a773d463101ef827849ef847ddbbe881.tif',
+    'intensificationnapp_rainfed_bmps': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_rainfed_n_app_bmps_md5_7637f211bb13a3ec66b00491d9518110.tif',
+    'extensificationnapp_rainfedfootprint_gapfilled': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/current_n_app_md5_a7e226b3418504591095a704c2409f16.tif',
+    'intensificationnapp_irrigated': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_irrigated_n_app_md5_f472499f546b92835e8011b2654b253a.tif',
+    'intensificationnapp_rainfed': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_rainfed_n_app_md5_48687737e6fdf931ddb163c6c9694e44.tif',
 }
 
+# JD sanity check to make sure these files exist.
+for key, value in ECOSHARDS.items():
+    if value.startswith(SHERLOCK_SCRATCH):
+        assert os.path.exists(value)
 
 # put IDs here that need to be scrubbed, you may know these a priori or you
 # may run the pipeline and see an error and realize you need to add them

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -68,13 +68,12 @@ for key, value in ECOSHARDS.items():
 
 # put IDs here that need to be scrubbed, you may know these a priori or you
 # may run the pipeline and see an error and realize you need to add them
-float_nan = float('nan')
 SCRUB_IDS = {
-    'intensificationnapp_irrigated_bmps': float_nan,
-    'intensificationnapp_rainfed_bmps': float_nan,
-    'extensificationnapp_rainfedfootprint_gapfilled': float_nan,
-    'intensificationnapp_irrigated': float_nan,
-    'intensificationnapp_rainfed': float_nan,
+    'intensificationnapp_irrigated_bmps',
+    'intensificationnapp_rainfed_bmps',
+    'extensificationnapp_rainfedfootprint_gapfilled',
+    'intensificationnapp_irrigated',
+    'intensificationnapp_rainfed',
 }
 
 # DEFINE SCENARIOS HERE SPECIFYING 'lulc_id', 'precip_id', 'fertilizer_id', and 'biophysical_table_id'

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -71,7 +71,6 @@ for key, value in ECOSHARDS.items():
 SCRUB_IDS = {
     'intensificationnapp_irrigated_bmps',
     'intensificationnapp_rainfed_bmps',
-    'extensificationnapp_rainfedfootprint_gapfilled',
     'intensificationnapp_irrigated',
     'intensificationnapp_rainfed',
 }

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -56,7 +56,7 @@ ECOSHARDS = {
     ## these ecoshards there at the moment.
     'intensificationnapp_irrigated_bmps': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_irrigated_n_app_bmps_md5_a773d463101ef827849ef847ddbbe881.tif',
     'intensificationnapp_rainfed_bmps': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_rainfed_n_app_bmps_md5_7637f211bb13a3ec66b00491d9518110.tif',
-    'extensificationnapp_rainfedfootprint_gapfilled': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/current_n_app_md5_a7e226b3418504591095a704c2409f16.tif',
+    'extensificationnapp_rainfedfootprint_gapfilled': f'{SHERLOCK_SCRATCH}/nci-ecoshards/finaltotalNfertratescurrentRevQ_add_background_md5_bd57fc740fe61b99133a4e22d3e89ece.tif',
     'intensificationnapp_irrigated': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_irrigated_n_app_md5_f472499f546b92835e8011b2654b253a.tif',
     'intensificationnapp_rainfed': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_rainfed_n_app_md5_48687737e6fdf931ddb163c6c9694e44.tif',
 }

--- a/scenarios/nci_global.py
+++ b/scenarios/nci_global.py
@@ -27,7 +27,7 @@ ECOSHARDS = {
     'fixedarea_intensified_irrigated': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/scenarios052320_fixedarea_intensified_irrigated_md5_0b96c3ff00696a454d6c2fffb2ee1415.tif',
     'fixedarea_intensified_rainfed': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/scenarios052320_fixedarea_intensified_rainfed_md5_ec3a78c825186a12c16f3f7442eb03f4.tif',
     'grazing_expansion_lulc': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/scenarios0221_grazing_expansion_md5_140803bc8aef02a1742aa1d1757e9e76.tif',
-    'restoration': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/scenarios0221_restoration_md5_16450b43f0a232b32a847c9738affda3.tif',
+    'restoration_lulc': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/scenarios0221_restoration_md5_16450b43f0a232b32a847c9738affda3.tif',
     'sustainable_current': f'{ECOSHARD_PREFIX}nci-ecoshards/one_last_run/scenarios0321_sustainable_current_md5_82afe022ffa8485a9b10154ee844b54f.tif',
 
     # Fertilizer
@@ -59,6 +59,13 @@ ECOSHARDS = {
     'extensificationnapp_rainfedfootprint_gapfilled': f'{SHERLOCK_SCRATCH}/nci-ecoshards/finaltotalNfertratescurrentRevQ_add_background_md5_bd57fc740fe61b99133a4e22d3e89ece.tif',
     'intensificationnapp_irrigated': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_irrigated_n_app_md5_f472499f546b92835e8011b2654b253a.tif',
     'intensificationnapp_rainfed': f'{SHERLOCK_SCRATCH}/nci-ecoshards/fertilizer-layers-2022-03-08/intensified_rainfed_n_app_md5_48687737e6fdf931ddb163c6c9694e44.tif',
+
+    # Section 4 - These are the additional LULCs that Rafa and Becky said
+    # should be used for the Forestry, Grazing and Restoration scenarios.
+    # These rasters are merely ecosharded versions of the rasters contained at
+    # https://drive.google.com/drive/u/1/folders/13g52ihP7G2WrYuzl6-gO9yuCwhD3AEw-
+    # The grazing_expansion_lulc and restoration_lulc were already ecosharded.
+    'forestry_expansion_lulc': f'{SHERLOCK_SCRATCH}/nci-ecoshards/forestry_expansion_md5_215cd2a3db0c8a1a5451f395e87568ec.tif',
 }
 
 # JD sanity check to make sure these files exist.
@@ -132,18 +139,24 @@ SCENARIOS = {
         'fertilizer_id': 'intensificationnapp_irrigated',
         'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',
     },
-    #'grazing_expansion': {
-    #    'lulc_id': 'grazing_expansion_lulc',
-    #    'precip_id': 'worldclim_2015',
-    #    'fertilizer_id': 'extensificationnapp_rainfedfootprint_gapfilled',
-    #    'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',
-    #},
-    #'restoration': {
-    #    'lulc_id': 'restoration',
-    #    'precip_id': 'worldclim_2015',
-    #    'fertilizer_id': 'extensificationnapp_rainfedfootprint_gapfilled',
-    #    'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',
-    #},
+    'forestry_expansion': {
+        'lulc_id': 'forestry_expansion_lulc',
+        'precip_id': 'worldclim_2015',
+        'fertilizer_id': 'extensificationnapp_rainfedfootprint_gapfilled',
+        'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',
+    },
+    'grazing_expansion': {
+        'lulc_id': 'grazing_expansion_lulc',
+        'precip_id': 'worldclim_2015',
+        'fertilizer_id': 'extensificationnapp_rainfedfootprint_gapfilled',
+        'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',
+    },
+    'restoration': {
+        'lulc_id': 'restoration_lulc',
+        'precip_id': 'worldclim_2015',
+        'fertilizer_id': 'extensificationnapp_rainfedfootprint_gapfilled',
+        'biophysical_table_id': 'nci-ndr-biophysical_table_forestry_grazing',
+    },
     'sustainable_currentpractices': {
         'lulc_id': 'sustainable_current',
         'precip_id': 'worldclim_2015',


### PR DESCRIPTION
These changes came up while running @beckyck 's latest scenarios on Sherlock, which has different constraints than how I believe this analysis was run before.  In my case, it was convenient to schedule each scenario individually and to keep each workspace separate.  So, these changes are really, really handy:

1. Enabling an environment-defined workspace meant that I could specify the target output workspace and avoid a possible filesystem collision if two scenarios happened to be executing on the same machine
2. Writing the various logfiles to the workspace avoids two problems:
    1. Output from all 10 requested scenarios would be interleaved in various `.out` files on the same filesystem, making errors more difficult to isolate
    2. Sherlock's `$HOME` is only 15GB in size, so potentially-large logfiles can easily exhaust the partition.  So long as I write the workspace to a larger filesystem, I don't have to worry about exhausting disk space.